### PR TITLE
Changed image for building windows libraries

### DIFF
--- a/.yamato/build-windows-x64.yml
+++ b/.yamato/build-windows-x64.yml
@@ -1,4 +1,4 @@
-name: Build protobuf - Windows 10 x64
+name: Build protobuf - Windows 10 x64 with VS 2017
 
 agent:
   type: Unity::VM

--- a/.yamato/build-windows-x64.yml
+++ b/.yamato/build-windows-x64.yml
@@ -2,7 +2,7 @@ name: Build protobuf - Windows 10 x64
 
 agent:
   type: Unity::VM
-  image: cds-ops/win10-vs2017:stable
+  image: desktop/desktop-vs2017:latest
   flavor: b1.medium
 
 artifacts:

--- a/.yamato/build-windows-x64.yml
+++ b/.yamato/build-windows-x64.yml
@@ -2,7 +2,7 @@ name: Build protobuf - Windows 10 x64
 
 agent:
   type: Unity::VM
-  image: desktop/desktop-vs2019:latest
+  image: cds-ops/win10-vs2017:stable
   flavor: b1.medium
 
 artifacts:


### PR DESCRIPTION
The image for building the windows libraries before used Visual Studio 2019. Some of our systems still require Visual Studio 2017.