### PR TITLE
Bump agg. and WhiteSource+CLA check

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,12 @@
+{
+  "scanSettings": {
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.google.protobuf</groupId>
   <artifactId>protobuf-bom</artifactId>
-  <version>3.8.0</version>
+  <version>3.16.1</version>
   <packaging>pom</packaging>
 
   <name>Protocol Buffers [BOM]</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <version>4.13.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -93,7 +93,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>26.0-android</version>
+        <version>29.0-android</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/ruby/pom.xml
+++ b/ruby/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.0.0</version>
+            <version>3.16.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
[Bump protobuf-java from 3.8.0 to 3.16.1 in /java/bom](https://github.com/Unity-Technologies/protobuf/commit/43f834cacf5fecc0269b77a712d501c792c890e2)

[Bump protobuf-java from 3.0.0 to 3.16.1 in /ruby](https://github.com/Unity-Technologies/protobuf/commit/806b879ed97b37c40410b24d080ec51a78e2a696)

[Bump guava from 26.0-android to 29.0-android in /java](https://github.com/Unity-Technologies/protobuf/commit/d1cbfd09344004074cba84b123a0d083ef910da2)

[Bump junit from 4.12 to 4.13.1 in /java](https://github.com/Unity-Technologies/protobuf/commit/6a4f335045b7729be79861c1102c5d6ab9f8e5d3)

plus CLA check, and .whitesource config. file.